### PR TITLE
Lock versions of build tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ RUN ./configure --enable-optimizations --enable-shared LDFLAGS='-Wl,-rpath /usr/
 RUN ln -snf "../local/bin/python$PY_VERSION" /usr/bin/python3 \
     && ln -snf "../local/bin/pip$PY_VERSION" /usr/bin/pip3
 
-RUN python3 -m pip install --no-cache-dir -U pip \
-    && python3 -m pip install --no-cache-dir -U setuptools \
-    && python3 -m pip install --no-cache-dir -U virtualenv \
-    && python3 -m pip install --no-cache-dir -U wheel
+RUN python3 -m pip install -U 'pip<23.0' \
+    && python3 -m pip install -U 'setuptools<62.4.0' \
+    && python3 -m pip install -U 'virtualenv<20.15.0' \
+    && python3 -m pip install -U 'wheel<0.38.0'
 
 WORKDIR /build

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,10 +1,10 @@
 @Library('csm-shared-library@main') _
 
 // Find a .tar.gz here: https://www.python.org/ftp/python/
-def pyVersion = '3.10.4'
+def pythonVersion = '3.10.4'
 
 // Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
-def (pyMajor, pyMinor, pyBugfix) = pyVersion.tokenize('.')
+def (pyMajor, pyMinor, pyBugfix) = pythonVersion.tokenize('.')
 
 def isStable = env.TAG_NAME != null || env.BRANCH_NAME == 'main' ? true : false
 pipeline {
@@ -24,7 +24,7 @@ pipeline {
         DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION)
         DOCKER_BUILDKIT = 1
         NAME = "csm-docker-sle-python"
-        PY_FULL_VERSION = "${pyVersion}"
+        PY_FULL_VERSION = "${pythonVersion}"
         PY_VERSION = "${pyMajor}.${pyMinor}"
         VERSION = "${GIT_COMMIT[0..6]}"
     }

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 NAME ?= ${NAME}
 DOCKER_BUILDKIT ?= ${DOCKER_BUILDKIT}
-PY_FULL_VERSION := $(shell awk -v replace="'" '/pyVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+PY_FULL_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 PY_VERSION := $(shell echo ${PY_FULL_VERSION} | awk -F '.' '{print $$1"."$$2}')
 VERSION ?= ${VERSION}
 


### PR DESCRIPTION
Lock the versions so they don't change major or minor versions, but allow bugfixes.