### PR TITLE
3.6.15 leap15.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,24 +31,14 @@ ARG PY_VERSION=''
 RUN zypper refresh \
     && zypper --non-interactive install --no-recommends --force-resolution \
     libffi-devel \
+    python3-devel \
+    python3-pip \
+    python3-setuptools \
+    python3-virtualenv \
+    python3-wheel \
     && zypper clean -a \
     && SUSEConnect --cleanup
 
-WORKDIR /root/.python
-RUN curl -O "https://www.python.org/ftp/python/$PY_FULL_VERSION/Python-$PY_FULL_VERSION.tar.xz" \
-    && tar -xvf "./Python-$PY_FULL_VERSION.tar.xz" \
-    && rm "Python-$PY_FULL_VERSION.tar.xz"
-
-WORKDIR "/root/.python/Python-$PY_FULL_VERSION"
-RUN ./configure --enable-optimizations --enable-shared LDFLAGS='-Wl,-rpath /usr/local/lib' \
-    && make altinstall
-
-RUN ln -snf "../local/bin/python$PY_VERSION" /usr/bin/python3 \
-    && ln -snf "../local/bin/pip$PY_VERSION" /usr/bin/pip3
-
-RUN python3 -m pip install --no-cache-dir -U pip \
-    && python3 -m pip install --no-cache-dir -U setuptools \
-    && python3 -m pip install --no-cache-dir -U virtualenv \
-    && python3 -m pip install --no-cache-dir -U wheel
+RUN ln -snf /usr/bin/python3 /usr/bin/python
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,8 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.3 AS base
+FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.2 AS base
 
-RUN --mount=type=secret,id=SLES_REGISTRATION_CODE SUSEConnect -r "$(cat /run/secrets/SLES_REGISTRATION_CODE)"
 CMD ["/bin/bash"]
 FROM base AS py-base
 
@@ -37,7 +36,6 @@ RUN zypper refresh \
     python3-virtualenv \
     python3-wheel \
     && zypper clean -a \
-    && SUSEConnect --cleanup
 
 RUN ln -snf /usr/bin/python3 /usr/bin/python
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,7 +1,7 @@
 @Library('csm-shared-library@main') _
 
 // Find a .tar.gz here: https://www.python.org/ftp/python/
-def pyVersion = '3.10.4'
+def pyVersion = '3.6.15'
 
 // Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
 def (pyMajor, pyMinor, pyBugfix) = pyVersion.tokenize('.')

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,10 +1,13 @@
 @Library('csm-shared-library@main') _
 
 // Find a .tar.gz here: https://www.python.org/ftp/python/
-def pyVersion = '3.6.15'
+def pythonVersion = '3.6.15'
+
+// Version of openSUSE Leap that this build against.
+def leapVersion = '15.2'
 
 // Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
-def (pyMajor, pyMinor, pyBugfix) = pyVersion.tokenize('.')
+def (pyMajor, pyMinor, pyBugfix) = pythonVersion.tokenize('.')
 
 def isStable = env.TAG_NAME != null || env.BRANCH_NAME == 'main' ? true : false
 pipeline {
@@ -24,7 +27,7 @@ pipeline {
         DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION)
         DOCKER_BUILDKIT = 1
         NAME = "csm-docker-sle-python"
-        PY_FULL_VERSION = "${pyVersion}"
+        PY_FULL_VERSION = "${pythonVersion}"
         PY_VERSION = "${pyMajor}.${pyMinor}"
         VERSION = "${GIT_COMMIT[0..6]}"
     }
@@ -45,8 +48,8 @@ pipeline {
             steps {
                 script {
                     publishCsmDockerImage(image: env.NAME, tag: env.VERSION, isStable: isStable)
-                    publishCsmDockerImage(image: env.NAME, tag: env.PY_FULL_VERSION, isStable: isStable)
-                    publishCsmDockerImage(image: env.NAME, tag: env.PY_VERSION, isStable: isStable)
+                    publishCsmDockerImage(image: env.NAME, tag: "${env.PY_FULL_VERSION}_leap${leapVersion}", isStable: isStable)
+                    publishCsmDockerImage(image: env.NAME, tag: "${env.PY_VERSION}_leap${leapVersion}", isStable: isStable)
                     publishCsmDockerImage(image: env.NAME, tag: "latest", isStable: isStable)
                 }
             }

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 NAME ?= ${NAME}
 DOCKER_BUILDKIT ?= ${DOCKER_BUILDKIT}
-PY_FULL_VERSION := $(shell awk -v replace="'" '/pyVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+LEAP_VERSION := $(shell awk -v replace="'" '/leapVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+PY_FULL_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 PY_VERSION := $(shell echo ${PY_FULL_VERSION} | awk -F '.' '{print $$1"."$$2}')
 VERSION ?= ${VERSION}
 
@@ -29,6 +30,6 @@ all: image
 
 image:
 	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg PY_VERSION=${PY_VERSION} --build-arg PY_FULL_VERSION=${PY_FULL_VERSION} --tag '${NAME}:${VERSION}' .
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}_leap${LEAP_VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_VERSION}_leap${LEAP_VERSION}
 	docker tag '${NAME}:${VERSION}' ${NAME}:latest


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-3600

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This produces a Python3.6 image running SP2 which provides an older GLIBC:
```bash
glibc-2.26-lp152.26.12.1.x86_64
```

This enables Python applications that require libc to build for a broader set of target OSes.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->

None.