### PR TITLE
MTL-1947 Build on cron and use timestamps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,8 +25,6 @@
 <!--- invalid checkbox: [] -->
 
 - [ ] I have included documentation in my PR (or it is not required)
-- [ ] I tested this on internal system (if yes, please include results or a description of the test)
-- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
  
 ### Idempotency
  

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,3 +1,28 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
 @Library('csm-shared-library@main') _
 
 // Find a .tar.gz here: https://www.python.org/ftp/python/
@@ -6,7 +31,16 @@ def pythonVersion = '3.10.4'
 // Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
 def (pyMajor, pyMinor, pyBugfix) = pythonVersion.tokenize('.')
 
-def isStable = env.TAG_NAME != null || env.BRANCH_NAME == 'main' ? true : false
+// Disable pr-merge builds; node-image pipeline doesn't use the PR images at all.
+if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
+    currentBuild.result = 'SUCCESS'
+    echo "Pull-Requests are not built for node-image-build; this is a no-op build."
+    return
+}
+
+// Only main or maint/* branches are stable.
+def promotionToken = ~"(main|maint\\/.*)"
+def isStable = env.BRANCH_NAME ==~ promotionToken ? true : false
 pipeline {
     agent {
         label "metal-gcp-builder"
@@ -20,11 +54,12 @@ pipeline {
     }
 
     environment {
-        DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION)
+        DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A build environment for Python.')
         DOCKER_BUILDKIT = 1
         NAME = getRepoName()
         PY_FULL_VERSION = "${pythonVersion}"
         PY_VERSION = "${pyMajor}.${pyMinor}"
+        TIMESTAMP = sh(returnStdout: true, script: "date '+%Y%m%d%H%M%S'").trim()
         VERSION = "${GIT_COMMIT[0..6]}"
     }
 
@@ -43,9 +78,29 @@ pipeline {
         stage('Publish') {
             steps {
                 script {
-                    publishCsmDockerImage(image: env.NAME, tag: env.VERSION, isStable: isStable)
-                    publishCsmDockerImage(image: env.NAME, tag: env.PY_FULL_VERSION, isStable: isStable)
-                    publishCsmDockerImage(image: env.NAME, tag: env.PY_VERSION, isStable: isStable)
+
+                    // Only overwrite an image if this is a stable build.
+                    if (isStable) {
+                        /*
+                        Publish these tags on stable:
+                            - Major.Minor.Patch-Hash-Timestamp    (e.g. 3.10.4-dhckj3-20221017133121)
+                            - Major.Minor.Patch-Hash-Timestamp    (e.g. 3.10.4-dhckj3)
+                            - Major.Minor.Patch                   (e.g. 3.10.4)
+                            - Major.Minor                         (e.g. 3.10)
+                        */
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                    } else {
+                        /*
+                        Publish these tags on unstable:
+                            - Hash                          (e.g. dhckj3)
+                            - Hash-Timestamp                (e.g. dhckj3-20221017133121)
+                        */
+                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                    }
                 }
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,17 @@ DOCKER_BUILDKIT ?= ${DOCKER_BUILDKIT}
 PY_FULL_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 PY_VERSION := $(shell echo ${PY_FULL_VERSION} | awk -F '.' '{print $$1"."$$2}')
 VERSION ?= ${VERSION}
+ifeq ($(TIMESTAMP),)
+TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
+endif
 
 all: image
 
 image:
 	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg PY_VERSION=${PY_VERSION} --build-arg PY_FULL_VERSION=${PY_FULL_VERSION} --tag '${NAME}:${VERSION}' .
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${VERSION}-${TIMESTAMP}
 	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}-${TIMESTAMP}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}-${TIMESTAMP}

--- a/README.adoc
+++ b/README.adoc
@@ -1,34 +1,36 @@
-# CSM Docker: SLE Python
+= CSM Docker: SLE Python
 
 A SLE Server Python Docker image used for RPM builds.
 
-## Available Images
+== Available Images
 
 See a list of available Python Images with `git tag`, but in general there are:
 
-- `3.10`, and `3.10.4`
-- `3.8` and `3.8.13`
-- `3.6` and `3.6.15`
-- `3.6_leap15.2` and `3.6.15_leap15.2`
+* `3.10`, and `3.10.4`
+* `3.8` and `3.8.13`
+* `3.6` and `3.6.15`
+* `3.6_leap15.2` and `3.6.15_leap15.2`
 
-Tags can also be seen directly at [https://artifactory.algol60.net/artifactory/csm-docker/stable/csm-docker-sle-python](https://artifactory.algol60.net/artifactory/csm-docker/stable/csm-docker-sle-python).
+Tags can also be seen directly at https://artifactory.algol60.net/artifactory/csm-docker/stable/csm-docker-sle-python.
 
-## Building
+== Building
 
 The provided `Makefile` adds Jenkins Pipeline variables to the `docker build` command. The commands below are for use outside of the CSM Jenkins Pipeline.
 
-```bash
+[source,bash]
+----
 export DOCKER_BUILDKIT=1
 export SLES_REGISTRATION_CODE=<registration_code>
 
 # Build Python 3.8.13
 docker build --secret id=SLES_REGISTRATION_CODE --build-arg PY_FULL_VERSION=3.10.4 .
 
-```
+----
 
-## Running
+== Running
 
-```bash
+[source,bash]
+----
 # Python Major Minor Version
 docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.8
 
@@ -37,12 +39,24 @@ docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3
 
 # Git Hash
 docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:<hash>
-```
+----
 
-## Python Version(s)
+== Python Version(s)
 
-The version is controlled by the `Dockerfile`. Each image built and pushed to Artifactory is tagged with:
-- `latest`
-- A short Git hash
-- The Python Version from the [`Jenkinsfile`](https://github.com/Cray-HPE/csm-docker-sle-python/blob/main/Jenkinsfile.github#L4)
+The version is controlled by the `Jenkinsfile`.
 
+Unstable image tags will publish using these tags:
+
+* `[HASH]`
+* `[HASH]-[TIMESTAMP]`
+
+Stable image tags will publish using these tags:
+
+* `[MAJOR.MINOR]`
+* `[MAJOR.MINOR.PATCH]`
+* `[MAJOR.MINOR.PATCH]-[HASH]`
+* `[MAJOR.MINOR.PATCH]-[HASH]-[TIMESTAMP]`
+
+=== Updating Python
+
+To use a newer version of GoLang, update the `Jenkinsfile` with a new `pythonVersion`.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1947

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This will auto-build new images to prevent our available images from becoming stale, while also including a timestamp in the image

This also makes `main` and `maint/*` branches the only stable builds, dismissing git-tags.

The problem with git-tags is we will have to move the tag everytime we update `main` or a `maint/` branch, this overhead might fall through the cracks.

By building a stable on a merge, the short image tags (e.g. 15.3) won't have stale/misleading git-tags.

**After merging this, I'll create `maint/` branches and remove our git-tags before cleaning Artifactory and doing a full rebuild of every stable image.**

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
