### PR TITLE
MTL-1947 Forgot cron trigger

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -53,6 +53,9 @@ pipeline {
         timestamps()
     }
 
+    // Run every week on Sunday at 4 PM, long after the base image has rebuilt from that morning.
+    triggers{ cron('H 16 * * 0') }
+
     environment {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A build environment for Python.')
         DOCKER_BUILDKIT = 1

--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,3 @@ image:
 	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}
 	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}
 	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}-${TIMESTAMP}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}-${TIMESTAMP}


### PR DESCRIPTION
PR #9 ported the `Jenkinsfile` from `csm-docker-sle` but didn't include the cron trigger.