### PR TITLE
MTL-1708 Built SP4 and SP3 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.4 AS base
+ARG SLE_VERSION
+FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${SLE_VERSION} AS base
 
 RUN --mount=type=secret,id=SLES_REGISTRATION_CODE SUSEConnect -r "$(cat /run/secrets/SLES_REGISTRATION_CODE)"
 CMD ["/bin/bash"]

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -27,9 +27,10 @@
 
 // Find a .tar.gz here: https://www.python.org/ftp/python/
 def pythonVersion = '3.10.8'
-
 // Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
 def (pyMajor, pyMinor, pyBugfix) = pythonVersion.tokenize('.')
+// Define the distro that the major.minor and major.minor.patch Docker tags publish to.
+def mainSleVersion = '15.4'
 
 // Disable pr-merge builds; node-image pipeline doesn't use the PR images at all.
 if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
@@ -42,6 +43,7 @@ if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
 def promotionToken = ~"(main|maint\\/.*)"
 def isStable = env.BRANCH_NAME ==~ promotionToken ? true : false
 pipeline {
+
     agent {
         label "metal-gcp-builder"
     }
@@ -54,7 +56,7 @@ pipeline {
     }
 
     // Run every week on Sunday at 4 PM, long after the base image has rebuilt from that morning.
-    triggers{ cron('H 16 * * 0') }
+    triggers { cron('H 16 * * 0') }
 
     environment {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A build environment for Python.')
@@ -68,41 +70,68 @@ pipeline {
 
     stages {
 
-        stage('Build') {
-            steps {
-                withCredentials([
-                    string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
-                ]) {
-                    sh "make image"
+        stage('Build & Publish') {
+
+            matrix {
+
+                axes {
+                    axis {
+                        name 'sleVersion'
+                        values 15.3, 15.4
+                    }
                 }
-            }
-        }
 
-        stage('Publish') {
-            steps {
-                script {
+                stages {
 
-                    // Only overwrite an image if this is a stable build.
-                    if (isStable) {
-                        /*
-                        Publish these tags on stable:
-                            - Major.Minor.Patch-Hash-Timestamp    (e.g. 3.10.4-dhckj3-20221017133121)
-                            - Major.Minor.Patch-Hash-Timestamp    (e.g. 3.10.4-dhckj3)
-                            - Major.Minor.Patch                   (e.g. 3.10.4)
-                            - Major.Minor                         (e.g. 3.10)
-                        */
-                        publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                    } else {
-                        /*
-                        Publish these tags on unstable:
-                            - Hash                          (e.g. dhckj3)
-                            - Hash-Timestamp                (e.g. dhckj3-20221017133121)
-                        */
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                    stage('Build') {
+                        environment {
+                            SLE_VERSION = "${sleVersion}"
+                        }
+                        steps {
+                            withCredentials([
+                                    string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
+                            ]) {
+                                sh "make image"
+                            }
+                        }
+                    }
+
+                    stage('Publish') {
+                        steps {
+                            script {
+
+                                // Only overwrite an image if this is a stable build.
+                                if (isStable) {
+                                    /*
+                                    Publish these tags on stable:
+                                        - Major.Minor.Patch-Distro-Hash-Timestamp    (e.g. 3.10.8-SLES15.4-dhckj3-20221017133121)
+                                        - Major.Minor.Patch-Distro-Hash-Timestamp    (e.g. 3.10.8-SLES15.4-dhckj3)
+                                        - Major.Minor.Patch-Distro                   (e.g. 3.10.8-SLES15.4)
+                                        - Major.Minor.Patch                          (e.g. 3.10.8)
+                                        - Major.Minor-Distro                         (e.g. 3.10-SLES15.4)
+                                        - Major.Minor                                (e.g. 3.10)
+                                    */
+                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES-${sleVersion}-${env.VERSION}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}-SLES${sleVersion}", isStable: isStable)
+
+                                    // Only publish the simple version images on the latest/newest base image.
+                                    if ("${sleVersion}" == "${mainSleVersion}") {
+                                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}", isStable: isStable)
+                                        publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}", isStable: isStable)
+                                    }
+                                } else {
+                                    /*
+                                    Publish these tags on unstable:
+                                        - Hash-Timestamp                (e.g. SLES15.4-dhckj3-20221017133121)
+                                        - Hash                          (e.g. SLES15.4-dhckj3)
+                                    */
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${sleVersion}-${env.VERSION}", isStable: isStable)
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -26,7 +26,7 @@
 @Library('csm-shared-library@main') _
 
 // Find a .tar.gz here: https://www.python.org/ftp/python/
-def pythonVersion = '3.10.4'
+def pythonVersion = '3.10.8'
 
 // Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
 def (pyMajor, pyMinor, pyBugfix) = pythonVersion.tokenize('.')

--- a/Makefile
+++ b/Makefile
@@ -19,21 +19,49 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-NAME ?= ${NAME}
-DOCKER_BUILDKIT ?= ${DOCKER_BUILDKIT}
+ifeq ($(NAME),)
+NAME := $(shell basename $(shell pwd))
+endif
+
+ifeq ($(DOCKER_BUILDKIT),)
+DOCKER_BUILDKIT ?= 1
+endif
+
+ifeq ($(SLE_VERSION),)
+SLE_VERSION := $(shell awk -v replace="'" '/mainSleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+endif
+
+ifeq ($(PY_FULL_VERSION),)
 PY_FULL_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 PY_VERSION := $(shell echo ${PY_FULL_VERSION} | awk -F '.' '{print $$1"."$$2}')
-VERSION ?= ${VERSION}
+endif
+
 ifeq ($(TIMESTAMP),)
 TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
 endif
 
+ifeq ($(VERSION),)
+VERSION ?= $(shell git rev-parse --short HEAD)
+endif
+
 all: image
 
-image:
-	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg PY_VERSION=${PY_VERSION} --build-arg PY_FULL_VERSION=${PY_FULL_VERSION} --tag '${NAME}:${VERSION}' .
-	docker tag '${NAME}:${VERSION}' ${NAME}:${VERSION}-${TIMESTAMP}
+.PHONY: print
+print:
+	@printf "%-20s: %s\n" Name $(NAME)
+	@printf "%-20s: %s\n" DOCKER_BUILDKIT $(DOCKER_BUILDKIT)
+	@printf "%-20s: %s\n" 'Python Version' $(PY_VERSION)
+	@printf "%-20s: %s\n" 'SLE Version' $(SLE_VERSION)
+	@printf "%-20s: %s\n" Timestamp $(TIMESTAMP)
+	@printf "%-20s: %s\n" Version $(VERSION)
+
+image: print
+	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg SLE_VERSION=${SLE_VERSION} --build-arg PY_VERSION=${PY_VERSION} --build-arg PY_FULL_VERSION=${PY_FULL_VERSION} --tag '${NAME}:${VERSION}' .
+	docker tag '${NAME}:${VERSION}' ${NAME}:SLES${SLE_VERSION}-${VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}
 	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_VERSION}
 	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}-${TIMESTAMP}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_VERSION}-SLES${SLE_VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}-${VERSION}
+	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}

--- a/README.adoc
+++ b/README.adoc
@@ -2,16 +2,8 @@
 
 A SLE Server Python Docker image used for RPM builds.
 
-== Available Images
-
-See a list of available Python Images with `git tag`, but in general there are:
-
-* `3.10`, and `3.10.4`
-* `3.8` and `3.8.13`
-* `3.6` and `3.6.15`
-* `3.6_leap15.2` and `3.6.15_leap15.2`
-
-Tags can also be seen directly at https://artifactory.algol60.net/artifactory/csm-docker/stable/csm-docker-sle-python.
+Available images can only be seen by querying the Docker API or
+https://artifactory.algol60.net/artifactory/csm-docker/stable/csm-docker-sle-python[visiting the registry itself].
 
 == Building
 
@@ -22,23 +14,23 @@ The provided `Makefile` adds Jenkins Pipeline variables to the `docker build` co
 export DOCKER_BUILDKIT=1
 export SLES_REGISTRATION_CODE=<registration_code>
 
-# Build Python 3.8.13
-docker build --secret id=SLES_REGISTRATION_CODE --build-arg PY_FULL_VERSION=3.10.4 .
-
+# Build Python 3.10.8
+docker build --secret id=SLES_REGISTRATION_CODE --build-arg PY_FULL_VERSION=3.10.8 .
 ----
 
 == Running
 
 [source,bash]
 ----
-# Python Major Minor Version
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.8
+# Python version (major.minor)
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10-SLES15.4
 
-# Python Version
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.8.13
+# Python version (major.minor.bugfix)
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10.8
 
-# Git Hash
+# Python version (major.minor.bugfix) and distro
 docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:<hash>
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10.8-SLES15.4
 ----
 
 == Python Version(s)
@@ -47,15 +39,18 @@ The version is controlled by the `Jenkinsfile`.
 
 Unstable image tags will publish using these tags:
 
-* `[HASH]`
-* `[HASH]-[TIMESTAMP]`
+* `[DISTRO]-[HASH]`
+* `[DISTRO]-[HASH]-[TIMESTAMP]`
 
 Stable image tags will publish using these tags:
 
+.The `[MAJOR.MINOR]` image is only created against the latest distro.
 * `[MAJOR.MINOR]`
+* `[MAJOR.MINOR]-[DISTRO]`
 * `[MAJOR.MINOR.PATCH]`
-* `[MAJOR.MINOR.PATCH]-[HASH]`
-* `[MAJOR.MINOR.PATCH]-[HASH]-[TIMESTAMP]`
+* `[MAJOR.MINOR.PATCH]-[DISTRO]`
+* `[MAJOR.MINOR.PATCH]-[DISTRO]-[HASH]`
+* `[MAJOR.MINOR.PATCH]-[DISTRO]-[HASH]-[TIMESTAMP]`
 
 === Updating Python
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1708

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This implements a matrix to build against any SLES base image and publishes more specific Docker containing the distro information.

A basic tag will still be provided that contains just the Python version, however this tag will only be published for whichever SLES version is set in `mainSleVersion` in the `Jenkinsfile`. So `csm-docker-sle-python:3.10` will be built on SP4, but a user could use `csm-docker-sle-python:3.10-SLES15.3` to grab the SP3 base version.

Lastly the `Makefile` was modified to work outside of our Jenkins environment in order to facilitate local development.

**Example tags:**

*Stable:*
- csm-docker-sle-python:3.10.8-SLES15.3-dhckj3-20221017133121
- csm-docker-sle-python:3.10.8-SLES15.3-dhckj3
- csm-docker-sle-python:3.10.8-SLES15.3
- csm-docker-sle-python:3.10.8-SLES15.4-dhckj3-20221017133121
- csm-docker-sle-python:3.10.8-SLES15.4-dhckj3
- csm-docker-sle-python:3.10.8-SLES15.4
- csm-docker-sle-python:3.10.8
- csm-docker-sle-python:3.10-SLES15.3
- csm-docker-sle-python:3.10-SLES15.4
- csm-docker-sle-python:3.10

*Unstable:*
- csm-docker-sle-python:SLES15.3-dhckj3-20221017133121
- csm-docker-sle-python:SLES15.3-dhckj3
- csm-docker-sle-python:SLES15.4-dhckj3-20221017133121
- csm-docker-sle-python:SLES15.4-dhckj3

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
