### PR TITLE
`update-alternatives` with version specific target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,9 @@ RUN ./configure --enable-optimizations --enable-shared LDFLAGS='-Wl,-rpath /usr/
     && make altinstall
 
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python${PY_VERSION} 1 \
-    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip${PY_VERSION} 1
+    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip${PY_VERSION} 1 \
+    && update-alternatives --install /usr/bin/python${PY_VERSION} python${PY_VERSION} /usr/local/bin/python${PY_VERSION} 1 \
+    && update-alternatives --install /usr/bin/pip${PY_VERSION} pip${PY_VERSION} /usr/local/bin/pip${PY_VERSION} 1
 
 RUN python3 -m pip install -U 'pip<23.0' \
     && python3 -m pip install -U 'setuptools<62.4.0' \


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request


<!--- words; describe what this change is and what it is for. -->
The `python-rpm-macros` will look for all `python_flavors` in `/usr/bin`, this means if a user specifies `python3.10` as a flavor then their RPM build looks for `/usr/bin/python3.10`. In order to support this, we must make version specific updates to `/usr/bin` as well as the major version updates.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
