### PR TITLE
Fix Clobbering Race Condition

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -27,8 +27,10 @@
 
 // Find a .tar.gz here: https://www.python.org/ftp/python/
 def pythonVersion = '3.10.8'
+
 // Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
 def (pyMajor, pyMinor, pyBugfix) = pythonVersion.tokenize('.')
+
 // Define the distro that the major.minor and major.minor.patch Docker tags publish to.
 def mainSleVersion = '15.4'
 
@@ -63,7 +65,6 @@ pipeline {
         DOCKER_BUILDKIT = 1
         NAME = getRepoName()
         PY_FULL_VERSION = "${pythonVersion}"
-        PY_VERSION = "${pyMajor}.${pyMinor}"
         TIMESTAMP = sh(returnStdout: true, script: "date '+%Y%m%d%H%M%S'").trim()
         VERSION = "${GIT_COMMIT[0..6]}"
     }
@@ -76,17 +77,14 @@ pipeline {
 
                 axes {
                     axis {
-                        name 'sleVersion'
-                        values 15.3, 15.4
+                        name 'SLE_VERSION'
+                        values '15.3', '15.4'
                     }
                 }
 
                 stages {
 
                     stage('Build') {
-                        environment {
-                            SLE_VERSION = "${sleVersion}"
-                        }
                         steps {
                             withCredentials([
                                     string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
@@ -107,19 +105,22 @@ pipeline {
                                         - Major.Minor.Patch-Distro-Hash-Timestamp    (e.g. 3.10.8-SLES15.4-dhckj3-20221017133121)
                                         - Major.Minor.Patch-Distro-Hash-Timestamp    (e.g. 3.10.8-SLES15.4-dhckj3)
                                         - Major.Minor.Patch-Distro                   (e.g. 3.10.8-SLES15.4)
-                                        - Major.Minor.Patch                          (e.g. 3.10.8)
                                         - Major.Minor-Distro                         (e.g. 3.10-SLES15.4)
-                                        - Major.Minor                                (e.g. 3.10)
                                     */
-                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}-${env.VERSION}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}-SLES${sleVersion}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${SLE_VERSION}-${env.VERSION}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${SLE_VERSION}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}-SLES${SLE_VERSION}", isStable: isStable)
 
-                                    // Only publish the simple version images on the latest/newest base image.
-                                    if ("${sleVersion}" == "${mainSleVersion}") {
-                                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}", isStable: isStable)
+                                    /* Only publish the simple version images on the latest/newest base image.
+                                        - Major.Minor.Patch                          (e.g. 3.10.8)
+                                        - Major.Minor                                (e.g. 3.10)
+                                     */
+                                    if ("${SLE_VERSION}" == "${mainSleVersion}") {
+                                        sh "docker tag ${env.NAME}:${pyMajor}.${pyMinor}-SLES${mainSleVersion} ${env.NAME}:${pyMajor}.${pyMinor}"
+                                        sh "docker tag ${env.NAME}:${pythonVersion}-SLES${mainSleVersion} ${env.NAME}:${pythonVersion}"
                                         publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}", isStable: isStable)
+                                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}", isStable: isStable)
                                     }
                                 } else {
                                     /*
@@ -127,8 +128,8 @@ pipeline {
                                         - Hash-Timestamp                (e.g. SLES15.4-dhckj3-20221017133121)
                                         - Hash                          (e.g. SLES15.4-dhckj3)
                                     */
-                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${sleVersion}-${env.VERSION}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}", isStable: isStable)
                                 }
                             }
                         }

--- a/Makefile
+++ b/Makefile
@@ -20,28 +20,29 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 ifeq ($(NAME),)
-NAME := $(shell basename $(shell pwd))
+export NAME := $(shell basename $(shell pwd))
 endif
 
 ifeq ($(DOCKER_BUILDKIT),)
-DOCKER_BUILDKIT ?= 1
+export DOCKER_BUILDKIT ?= 1
 endif
 
 ifeq ($(SLE_VERSION),)
-SLE_VERSION := $(shell awk -v replace="'" '/mainSleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+export SLE_VERSION := $(shell awk -v replace="'" '/mainSleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 endif
 
 ifeq ($(PY_FULL_VERSION),)
-PY_FULL_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
-PY_VERSION := $(shell echo ${PY_FULL_VERSION} | awk -F '.' '{print $$1"."$$2}')
+export PY_FULL_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 endif
 
+export PY_VERSION := $(shell echo ${PY_FULL_VERSION} | awk -F '.' '{print $$1"."$$2}')
+
 ifeq ($(TIMESTAMP),)
-TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
+export TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
 endif
 
 ifeq ($(VERSION),)
-VERSION ?= $(shell git rev-parse --short HEAD)
+export VERSION ?= $(shell git rev-parse --short HEAD)
 endif
 
 all: image
@@ -56,13 +57,10 @@ print:
 	@printf "%-20s: %s\n" Version $(VERSION)
 
 image: print
-	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg SLE_VERSION=${SLE_VERSION} --build-arg PY_VERSION=${PY_VERSION} --build-arg PY_FULL_VERSION=${PY_FULL_VERSION} --tag '${NAME}:${VERSION}' .
-	docker tag '${NAME}:${VERSION}' ${NAME}:SLES${SLE_VERSION}-${VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_VERSION}-SLES${SLE_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}-${VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}
+	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg SLE_VERSION=${SLE_VERSION} --build-arg PY_VERSION=${PY_VERSION} --build-arg PY_FULL_VERSION=${PY_FULL_VERSION} --tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' .
+	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}'
+	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'
+	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}'
+	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}'
+	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}-${VERSION}'
+	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: https://github.com/Cray-HPE/csm-docker-sle-go/pull/9

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The 3.10 tagged images should correspond with the `mainSleVersion`, but this is not always true.

The past few 3.10 images I've pulled have been SP3. After inspecting build logs, there's a race condition due to a build agent overlap. Both the 15.3 and 15.4 stages run off the same `docker` process, and both take a `major.minor`, `version`, and `major.minor.micro` tag. Since both take those same three tags, whichever build stage runs last ends up taking the tag to be published.

Even the the publishing stage only pushes the `major.minor` and `major.minor.micro` tags for the `mainSleVersion`, if the non-`mainSleVersion` took the tags last then its tags will end up getting published.

This removes the conflict by only taking the conflicting tags from Jenkins, meaning the matrix builds all take their own unique tags.

This gets rid of the `hash` tag, since it will always overlap and it was never actually pushed.

Here one can see that the 3.10 image (which should be SP4) is really SP3:
```bash
[546]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/csm-docker-sle-python> docker ps -a
CONTAINER ID   IMAGE                                                                  COMMAND   CREATED       STATUS                     PORTS     NAMES
d4945614a2e1   artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10   "bash"    8 hours ago   Exited (130) 5 hours ago             relaxed_bell
[547]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/csm-docker-sle-python> docker start d4945614a2e1
d4945614a2e1
[548]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/csm-docker-sle-python> docker exec -it d4945614a2e1 bash
d4945614a2e1:/build # cat /etc/os-release
NAME="SLES"
VERSION="15-SP3"
VERSION_ID="15.3"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP3"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp3"
DOCUMENTATION_URL="https://documentation.suse.com/"
[551]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/csm-docker-sle-python> docker stop d4945614a2e1
d4945614a2e1
[552]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/csm-docker-sle-python> docker rm d4945614a2e1
dockerd4945614a2e1
[553]rusty@C02F43JEMD6P:~/gitstuffs/cray-shasta/csm-docker-sle-python> docker pull artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10
3.10: Pulling from csm-docker/stable/csm-docker-sle-python
Digest: sha256:d176c696c4b1ba702a5f6fe3eff7d7499de8e3df0c702e6bd0a5e81297ce1a3e
Status: Image is up to date for artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10
artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10
```

**This does not affect the `maint/` branches, because only `main` uses `matrix`.**

This also adds `export` to each variable definition in `Makefile`, ensuring that defaults are set for any context within the `Makefile`. Lastly this moves `PY_VERSION` out of the `ifeq` conditional for `PY_FULL_VERSION`, ensuring it's set when `PY_FULL_VERSION` is **not** empty (e.g. meaning the PIPELINE doesn't have to implicitly know to set this).


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
