### PR TITLE
Remove compiling step (3.10)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,9 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python
     && update-alternatives --install /usr/bin/python${PY_VERSION} python${PY_VERSION} /usr/local/bin/python${PY_VERSION} 1 \
     && update-alternatives --install /usr/bin/pip${PY_VERSION} pip${PY_VERSION} /usr/local/bin/pip${PY_VERSION} 1
 
-RUN python3 -m pip install -U 'pip~=23.0' \
-    && python3 -m pip install -U 'setuptools~=66.0' \
-    && python3 -m pip install -U 'virtualenv~=20.0' \
-    && python3 -m pip install -U 'wheel~=0.38'
+RUN python3 -m pip install -U 'pip' \
+    && python3 -m pip install -U 'setuptools' \
+    && python3 -m pip install -U 'virtualenv' \
+    && python3 -m pip install -U 'wheel'
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,9 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python
     && update-alternatives --install /usr/bin/python${PY_VERSION} python${PY_VERSION} /usr/local/bin/python${PY_VERSION} 1 \
     && update-alternatives --install /usr/bin/pip${PY_VERSION} pip${PY_VERSION} /usr/local/bin/pip${PY_VERSION} 1
 
-RUN python3 -m pip install -U 'pip' \
-    && python3 -m pip install -U 'setuptools' \
-    && python3 -m pip install -U 'virtualenv' \
-    && python3 -m pip install -U 'wheel'
+RUN python3 -m pip install -U 'pip~=23.0' \
+    && python3 -m pip install -U 'setuptools~=66.0' \
+    && python3 -m pip install -U 'virtualenv~=20.0' \
+    && python3 -m pip install -U 'wheel~=0.38'
 
 WORKDIR /build

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -26,7 +26,7 @@
 @Library('csm-shared-library@main') _
 
 // Find a .tar.gz here: https://www.python.org/ftp/python/
-def pythonVersion = '3.6.15'
+def pythonVersion = '3.10.8'
 
 // Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
 def (pyMajor, pyMinor, pyBugfix) = pythonVersion.tokenize('.')

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -25,14 +25,11 @@
  */
 @Library('csm-shared-library@main') _
 
-// Find a .tar.gz here: https://www.python.org/ftp/python/
-def pythonVersion = '3.10.8'
+// The Python version available from the SUSE repositories, with the period.
+def pythonVersion = '3.10'
 
-// Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
-def (pyMajor, pyMinor, pyBugfix) = pythonVersion.tokenize('.')
-
-// Define the distro that the major.minor and major.minor.patch Docker tags publish to.
-def mainSleVersion = '15.4'
+// Define the distro that provides our repositories for the given Python version.
+def sleVersion = '15.4'
 
 // Disable pr-merge builds; node-image pipeline doesn't use the PR images at all.
 if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
@@ -64,75 +61,52 @@ pipeline {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A build environment for Python.')
         DOCKER_BUILDKIT = 1
         NAME = getRepoName()
-        PY_FULL_VERSION = "${pythonVersion}"
         TIMESTAMP = sh(returnStdout: true, script: "date '+%Y%m%d%H%M%S'").trim()
         VERSION = "${GIT_COMMIT[0..6]}"
     }
 
     stages {
 
-        stage('Build & Publish') {
-
-            matrix {
-
-                axes {
-                    axis {
-                        name 'SLE_VERSION'
-                        values '15.3', '15.4'
-                    }
+        stage('Build') {
+            steps {
+                withCredentials([
+                        string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
+                ]) {
+                    sh "make image"
                 }
+            }
+        }
 
-                stages {
+        stage('Publish') {
+            steps {
+                script {
 
-                    stage('Build') {
-                        steps {
-                            withCredentials([
-                                    string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
-                            ]) {
-                                sh "make image"
-                            }
-                        }
-                    }
+                    // Only overwrite an image if this is a stable build.
+                    if (isStable) {
+                        /*
+                        Publish these tags on stable:
+                            - Major.Minor-Distro-Hash-Timestamp    (e.g. 3.10-SLES15.4-dhckj3-20221017133121)
+                            - Major.Minor-Distro-Hash-Timestamp    (e.g. 3.10-SLES15.4-dhckj3)
+                            - Major.Minor-Distro                   (e.g. 3.10-SLES15.4)
+                            - Major.Minor-Hash-Timestamp           (e.g. 3.10-dhckj3-20221017133121)
+                            - Major.Minor-Hash                     (e.g. 3.10-dhckj3)
+                            - Major.Minor                          (e.g. 3.10)
+                        */
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}-${env.VERSION}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}", isStable: isStable)
 
-                    stage('Publish') {
-                        steps {
-                            script {
-
-                                // Only overwrite an image if this is a stable build.
-                                if (isStable) {
-                                    /*
-                                    Publish these tags on stable:
-                                        - Major.Minor.Patch-Distro-Hash-Timestamp    (e.g. 3.10.8-SLES15.4-dhckj3-20221017133121)
-                                        - Major.Minor.Patch-Distro-Hash-Timestamp    (e.g. 3.10.8-SLES15.4-dhckj3)
-                                        - Major.Minor.Patch-Distro                   (e.g. 3.10.8-SLES15.4)
-                                        - Major.Minor-Distro                         (e.g. 3.10-SLES15.4)
-                                    */
-                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${SLE_VERSION}-${env.VERSION}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${SLE_VERSION}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}-SLES${SLE_VERSION}", isStable: isStable)
-
-                                    /* Only publish the simple version images on the latest/newest base image.
-                                        - Major.Minor.Patch                          (e.g. 3.10.8)
-                                        - Major.Minor                                (e.g. 3.10)
-                                     */
-                                    if ("${SLE_VERSION}" == "${mainSleVersion}") {
-                                        sh "docker tag ${env.NAME}:${pyMajor}.${pyMinor}-SLES${mainSleVersion} ${env.NAME}:${pyMajor}.${pyMinor}"
-                                        sh "docker tag ${env.NAME}:${pythonVersion}-SLES${mainSleVersion} ${env.NAME}:${pythonVersion}"
-                                        publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}", isStable: isStable)
-                                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}", isStable: isStable)
-                                    }
-                                } else {
-                                    /*
-                                    Publish these tags on unstable:
-                                        - Hash-Timestamp                (e.g. SLES15.4-dhckj3-20221017133121)
-                                        - Hash                          (e.g. SLES15.4-dhckj3)
-                                    */
-                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
-                                    publishCsmDockerImage(image: env.NAME, tag: "SLES${SLE_VERSION}-${env.VERSION}", isStable: isStable)
-                                }
-                            }
-                        }
+                    } else {
+                        /*
+                        Publish these tags on unstable:
+                            - Major.Minor-Hash-Timestamp           (e.g. 3.10-dhckj3-20221017133121)
+                            - Major.Minor-Hash                     (e.g. 3.10-dhckj3)
+                        */
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}", isStable: isStable)
                     }
                 }
             }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Cray / HPE
+Copyright (c) 2022-2023 Cray / HPE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 # MIT License
-# 
-# (C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
-# 
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -28,14 +28,13 @@ export DOCKER_BUILDKIT ?= 1
 endif
 
 ifeq ($(SLE_VERSION),)
-export SLE_VERSION := $(shell awk -v replace="'" '/mainSleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+export SLE_VERSION := $(shell awk -v replace="'" '/sleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 endif
 
-ifeq ($(PY_FULL_VERSION),)
-export PY_FULL_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+ifeq ($(PY_VERSION),)
+export PY_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 endif
 
-export PY_VERSION := $(shell echo ${PY_FULL_VERSION} | awk -F '.' '{print $$1"."$$2}')
 
 ifeq ($(TIMESTAMP),)
 export TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
@@ -57,10 +56,9 @@ print:
 	@printf "%-20s: %s\n" Version $(VERSION)
 
 image: print
-	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg SLE_VERSION=${SLE_VERSION} --build-arg PY_VERSION=${PY_VERSION} --build-arg PY_FULL_VERSION=${PY_FULL_VERSION} --tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' .
-	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}'
-	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'
-	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}'
-	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}'
-	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}-${VERSION}'
-	docker tag '${NAME}:${PY_VERSION}-SLES${SLE_VERSION}' '${NAME}:${PY_FULL_VERSION}-SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'
+	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg SLE_VERSION=${SLE_VERSION} --build-arg PY_VERSION=${PY_VERSION} --tag '${NAME}:${PY_VERSION}' .
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:SLES${SLE_VERSION}'
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}'
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:${PY_VERSION}-${VERSION}'
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:${PY_VERSION}-${VERSION}-${TIMESTAMP}'

--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ export DOCKER_BUILDKIT=1
 export SLES_REGISTRATION_CODE=<registration_code>
 
 # Build Python 3.10.8
-docker build --secret id=SLES_REGISTRATION_CODE --build-arg PY_FULL_VERSION=3.10.8 .
+docker build --secret id=SLES_REGISTRATION_CODE --build-arg PY_VERSION=3.10 .
 ----
 
 == Running
@@ -23,13 +23,10 @@ docker build --secret id=SLES_REGISTRATION_CODE --build-arg PY_FULL_VERSION=3.10
 [source,bash]
 ----
 # Python version (major.minor)
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10-SLES15.4
-
-# Python version (major.minor.bugfix)
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10.8
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10
 
 # Python version (major.minor.bugfix) and distro
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10.8-SLES15.4
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10-SLES15.4
 ----
 
 == Python Version(s)
@@ -45,11 +42,11 @@ Stable image tags will publish using these tags:
 
 .The `[MAJOR.MINOR]` image is only created against the latest distro.
 * `[MAJOR.MINOR]`
+* `[MAJOR.MINOR]-[HASH]`
+* `[MAJOR.MINOR]-[HASH]-[TIMESTAMP]`
 * `[MAJOR.MINOR]-[DISTRO]`
-* `[MAJOR.MINOR.PATCH]`
-* `[MAJOR.MINOR.PATCH]-[DISTRO]`
-* `[MAJOR.MINOR.PATCH]-[DISTRO]-[HASH]`
-* `[MAJOR.MINOR.PATCH]-[DISTRO]-[HASH]-[TIMESTAMP]`
+* `[MAJOR.MINOR]-[DISTRO]-[HASH]`
+* `[MAJOR.MINOR]-[DISTRO]-[HASH]-[TIMESTAMP]`
 
 === Updating Python
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This does a few things.

1. It undoes the accidental #23 PR, that was supposed to go to `maint/3.6.15`. That branch will be reconciled a different way, and the accidental merge to `main` needs to be reverted.
1. This removes the compile step, and the matrix. Changing the idea from "build Python version X.Y for distro A, B, and C" to "build Python version X.Y for distro A." This removes some complexity from the matrix build, and removes complexity for unused build cases (e.g. we never were using Python3.10 + SP3, SUSE doesn't support it, so why should we?).

This PR makes the `main` branch use official SUSE RPM packages for Python 3.10, native to SLES15SP4 repositories.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
