### PR TITLE
Remove compiling step (3.9)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -19,40 +19,42 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:15.3 AS base
+ARG SLE_VERSION
+FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${SLE_VERSION} AS base
 
 RUN --mount=type=secret,id=SLES_REGISTRATION_CODE SUSEConnect -r "$(cat /run/secrets/SLES_REGISTRATION_CODE)"
 CMD ["/bin/bash"]
 FROM base AS py-base
 
-ARG PY_FULL_VERSION=''
 ARG PY_VERSION=''
 
+# Install helpful build environment items:
+# NOTE: RPMs take precedence to PIP packages; install RPMs when available, and pip packages otherwise to avoid
+#       file conflicts.
+# - python-rpm-*      : Specfile macros.
+# - python-base       : Base Python package.
+# - python-devel      : Extensions and headers for building Python modules.
+# - python-pip        : The published/paired pip for the given Python base.
+# - python-setuptools : The published/paired setuptools for the given Python base.
 RUN zypper refresh \
     && zypper --non-interactive install --no-recommends --force-resolution \
-    libffi-devel \
     python-rpm-generators \
     python-rpm-macros \
+    python${PY_VERSION/\./}-base \
+    python${PY_VERSION/\./}-devel \
+    python${PY_VERSION/\./}-pip \
+    python${PY_VERSION/\./}-setuptools \
     && zypper clean -a \
     && SUSEConnect --cleanup
 
-WORKDIR /root/.python
-RUN curl -O "https://www.python.org/ftp/python/$PY_FULL_VERSION/Python-$PY_FULL_VERSION.tar.xz" \
-    && tar -xvf "./Python-$PY_FULL_VERSION.tar.xz" \
-    && rm "Python-$PY_FULL_VERSION.tar.xz"
+# Ensure python3 and pip3 point to our desired Python version.
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PY_VERSION} 1 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip${PY_VERSION} 1
 
-WORKDIR "/root/.python/Python-$PY_FULL_VERSION"
-RUN ./configure --enable-optimizations --enable-shared LDFLAGS='-Wl,-rpath /usr/local/lib' \
-    && make altinstall
-
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python${PY_VERSION} 1 \
-    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip${PY_VERSION} 1 \
-    && update-alternatives --install /usr/bin/python${PY_VERSION} python${PY_VERSION} /usr/local/bin/python${PY_VERSION} 1 \
-    && update-alternatives --install /usr/bin/pip${PY_VERSION} pip${PY_VERSION} /usr/local/bin/pip${PY_VERSION} 1
-
-RUN python3 -m pip install -U 'pip' \
-    && python3 -m pip install -U 'setuptools' \
-    && python3 -m pip install -U 'virtualenv' \
-    && python3 -m pip install -U 'wheel'
+# Install packages not available via Zypper.
+RUN python3 -m pip install --disable-pip-version-check --no-cache-dir -U \
+    'build' \
+    'virtualenv' \
+    'wheel'
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 # MIT License
-# 
+#
 # (C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -50,9 +50,9 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python
     && update-alternatives --install /usr/bin/python${PY_VERSION} python${PY_VERSION} /usr/local/bin/python${PY_VERSION} 1 \
     && update-alternatives --install /usr/bin/pip${PY_VERSION} pip${PY_VERSION} /usr/local/bin/pip${PY_VERSION} 1
 
-RUN python3 -m pip install -U 'pip<23.0' \
-    && python3 -m pip install -U 'setuptools<62.4.0' \
-    && python3 -m pip install -U 'virtualenv<20.15.0' \
-    && python3 -m pip install -U 'wheel<0.38.0'
+RUN python3 -m pip install -U 'pip' \
+    && python3 -m pip install -U 'setuptools' \
+    && python3 -m pip install -U 'virtualenv' \
+    && python3 -m pip install -U 'wheel'
 
 WORKDIR /build

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -25,11 +25,11 @@
  */
 @Library('csm-shared-library@main') _
 
-// Find a .tar.gz here: https://www.python.org/ftp/python/
-def pythonVersion = '3.9.13'
+// The Python version available from the SUSE repositories, with the period.
+def pythonVersion = '3.9'
 
-// Tokenize to enable major.minor image tags (e.g. make a 3.10 tag when building 3.10.4).
-def (pyMajor, pyMinor, pyBugfix) = pythonVersion.tokenize('.')
+// Define the distro that provides our repositories for the given Python version.
+def sleVersion = '15.3'
 
 // Disable pr-merge builds; node-image pipeline doesn't use the PR images at all.
 if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
@@ -54,14 +54,12 @@ pipeline {
     }
 
     // Run every week on Sunday at 4 PM, long after the base image has rebuilt from that morning.
-    triggers{ cron('H 16 * * 0') }
+    triggers { cron('H 16 * * 0') }
 
     environment {
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A build environment for Python.')
         DOCKER_BUILDKIT = 1
         NAME = getRepoName()
-        PY_FULL_VERSION = "${pythonVersion}"
-        PY_VERSION = "${pyMajor}.${pyMinor}"
         TIMESTAMP = sh(returnStdout: true, script: "date '+%Y%m%d%H%M%S'").trim()
         VERSION = "${GIT_COMMIT[0..6]}"
     }
@@ -71,7 +69,7 @@ pipeline {
         stage('Build') {
             steps {
                 withCredentials([
-                    string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
+                        string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
                 ]) {
                     sh "make image"
                 }
@@ -86,23 +84,28 @@ pipeline {
                     if (isStable) {
                         /*
                         Publish these tags on stable:
-                            - Major.Minor.Patch-Hash-Timestamp    (e.g. 3.10.4-dhckj3-20221017133121)
-                            - Major.Minor.Patch-Hash-Timestamp    (e.g. 3.10.4-dhckj3)
-                            - Major.Minor.Patch                   (e.g. 3.10.4)
-                            - Major.Minor                         (e.g. 3.10)
+                            - Major.Minor-Distro-Hash-Timestamp    (e.g. 3.9-SLES15.3-dhckj3-20221017133121)
+                            - Major.Minor-Distro-Hash-Timestamp    (e.g. 3.9-SLES15.3-dhckj3)
+                            - Major.Minor-Distro                   (e.g. 3.9-SLES15.3)
+                            - Major.Minor-Hash-Timestamp           (e.g. 3.9-dhckj3-20221017133121)
+                            - Major.Minor-Hash                     (e.g. 3.9-dhckj3)
+                            - Major.Minor                          (e.g. 3.9)
                         */
-                        publishCsmDockerImage(image: env.NAME, tag: "${pyMajor}.${pyMinor}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}-${env.VERSION}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-SLES${sleVersion}", isStable: isStable)
                         publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}", isStable: isStable)
+
                     } else {
                         /*
                         Publish these tags on unstable:
-                            - Hash                          (e.g. dhckj3)
-                            - Hash-Timestamp                (e.g. dhckj3-20221017133121)
+                            - Major.Minor-Hash-Timestamp           (e.g. 3.9-dhckj3-20221017133121)
+                            - Major.Minor-Hash                     (e.g. 3.9-dhckj3)
                         */
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}", isStable: isStable)
-                        publishCsmDockerImage(image: env.NAME, tag: "${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}-${env.TIMESTAMP}", isStable: isStable)
+                        publishCsmDockerImage(image: env.NAME, tag: "${pythonVersion}-${env.VERSION}", isStable: isStable)
                     }
                 }
             }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Cray / HPE
+Copyright (c) 2022-2023 Cray / HPE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 # MIT License
-# 
-# (C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
-# 
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included
 # in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -19,21 +19,46 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-NAME ?= ${NAME}
-DOCKER_BUILDKIT ?= ${DOCKER_BUILDKIT}
-PY_FULL_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
-PY_VERSION := $(shell echo ${PY_FULL_VERSION} | awk -F '.' '{print $$1"."$$2}')
-VERSION ?= ${VERSION}
+ifeq ($(NAME),)
+export NAME := $(shell basename $(shell pwd))
+endif
+
+ifeq ($(DOCKER_BUILDKIT),)
+export DOCKER_BUILDKIT ?= 1
+endif
+
+ifeq ($(SLE_VERSION),)
+export SLE_VERSION := $(shell awk -v replace="'" '/sleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+endif
+
+ifeq ($(PY_VERSION),)
+export PY_VERSION := $(shell awk -v replace="'" '/pythonVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
+endif
+
+
 ifeq ($(TIMESTAMP),)
-TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
+export TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
+endif
+
+ifeq ($(VERSION),)
+export VERSION ?= $(shell git rev-parse --short HEAD)
 endif
 
 all: image
 
-image:
-	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg PY_VERSION=${PY_VERSION} --build-arg PY_FULL_VERSION=${PY_FULL_VERSION} --tag '${NAME}:${VERSION}' .
-	docker tag '${NAME}:${VERSION}' ${NAME}:${VERSION}-${TIMESTAMP}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}
-	docker tag '${NAME}:${VERSION}' ${NAME}:${PY_FULL_VERSION}-${VERSION}-${TIMESTAMP}
+.PHONY: print
+print:
+	@printf "%-20s: %s\n" Name $(NAME)
+	@printf "%-20s: %s\n" DOCKER_BUILDKIT $(DOCKER_BUILDKIT)
+	@printf "%-20s: %s\n" 'Python Version' $(PY_VERSION)
+	@printf "%-20s: %s\n" 'SLE Version' $(SLE_VERSION)
+	@printf "%-20s: %s\n" Timestamp $(TIMESTAMP)
+	@printf "%-20s: %s\n" Version $(VERSION)
+
+image: print
+	docker build --secret id=SLES_REGISTRATION_CODE --pull ${DOCKER_ARGS} --build-arg SLE_VERSION=${SLE_VERSION} --build-arg PY_VERSION=${PY_VERSION} --tag '${NAME}:${PY_VERSION}' .
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:SLES${SLE_VERSION}'
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}'
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:SLES${SLE_VERSION}-${VERSION}-${TIMESTAMP}'
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:${PY_VERSION}-${VERSION}'
+	docker tag '${NAME}:${PY_VERSION}' '${NAME}:${PY_VERSION}-${VERSION}-${TIMESTAMP}'

--- a/README.adoc
+++ b/README.adoc
@@ -6,10 +6,9 @@ A SLE Server Python Docker image used for RPM builds.
 
 See a list of available Python Images with `git tag`, but in general there are:
 
-* `3.10`, and `3.10.4`
-* `3.8` and `3.8.13`
-* `3.6` and `3.6.15`
-* `3.6_leap15.2` and `3.6.15_leap15.2`
+* `3.10`
+* `3.9`
+* `3.6`
 
 Tags can also be seen directly at https://artifactory.algol60.net/artifactory/csm-docker/stable/csm-docker-sle-python.
 
@@ -22,23 +21,19 @@ The provided `Makefile` adds Jenkins Pipeline variables to the `docker build` co
 export DOCKER_BUILDKIT=1
 export SLES_REGISTRATION_CODE=<registration_code>
 
-# Build Python 3.8.13
-docker build --secret id=SLES_REGISTRATION_CODE --build-arg PY_FULL_VERSION=3.10.4 .
-
+# Build Python 3.9
+docker build --secret id=SLES_REGISTRATION_CODE --build-arg PY_VERSION=3.10 .
 ----
 
 == Running
 
 [source,bash]
 ----
-# Python Major Minor Version
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.8
-
 # Python Version
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.8.13
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.9
 
 # Git Hash
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:<hash>
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.9-<hash>
 ----
 
 == Python Version(s)
@@ -47,15 +42,14 @@ The version is controlled by the `Jenkinsfile`.
 
 Unstable image tags will publish using these tags:
 
-* `[HASH]`
-* `[HASH]-[TIMESTAMP]`
+* `[MAJOR.MINOR]-[HASH]`
+* `[MAJOR.MINOR]-[HASH]-[TIMESTAMP]`
 
 Stable image tags will publish using these tags:
 
 * `[MAJOR.MINOR]`
-* `[MAJOR.MINOR.PATCH]`
-* `[MAJOR.MINOR.PATCH]-[HASH]`
-* `[MAJOR.MINOR.PATCH]-[HASH]-[TIMESTAMP]`
+* `[MAJOR.MINOR]-[HASH]`
+* `[MAJOR.MINOR]-[HASH]-[TIMESTAMP]`
 
 === Updating Python
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This removes the compile step, and the matrix. Changing the idea from "build Python version X.Y for distro A, B, and C" to "build Python version X.Y for distro A." This removes some complexity from the matrix build, and removes complexity for unused build cases (e.g. we never were using Python3.9 + SP4, SUSE doesn't support it, so why should we?).

This PR makes the `maint/3.9` branch use official SUSE RPM packages for Python 3.9, native to SLES15SP3 repositories.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
