### PR TITLE
README tweaks

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -10,12 +10,14 @@ name: Hadolint
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'maint/**'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
-  schedule:
-    - cron: '16 1 * * 1'
+    branches:
+      - main
+      - 'maint/**'
 
 permissions:
   contents: read

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,6 @@
 = CSM Docker: SLE Python
+:toc:
+:toclevels: 3
 
 A SLE Server Python Docker image used for RPM builds.
 
@@ -6,34 +8,51 @@ A SLE Server Python Docker image used for RPM builds.
 
 See a list of available Python Images with `git tag`, but in general there are:
 
-* `3.10`
-* `3.9`
-* `3.6`
+.Stable Docker Tags
+[options="header",cols="m,1*^,m"]
+|===
+| Docker Tag | Base OS | GLIBC
+
+| 3.10
+| SLES-15-SP4
+| 2.31
+
+| 3.9
+| SLES-15-SP3
+| 2.31
+
+| 3.6
+| SLES-15-SP2
+| 2.26
+|===
 
 Tags can also be seen directly at https://artifactory.algol60.net/artifactory/csm-docker/stable/csm-docker-sle-python.
 
-== Building
+== Usage
 
-The provided `Makefile` adds Jenkins Pipeline variables to the `docker build` command. The commands below are for use outside of the CSM Jenkins Pipeline.
+The provided `Makefile` adds Jenkins Pipeline variables to the `docker build` command.
+The commands below are for use outside of the CSM Jenkins Pipeline.
 
 [source,bash]
 ----
 export DOCKER_BUILDKIT=1
 export SLES_REGISTRATION_CODE=<registration_code>
 
-# Build Python 3.9
-docker build --secret id=SLES_REGISTRATION_CODE --build-arg PY_VERSION=3.10 .
+make image
+
+docker run -it csm-docker-sle-python:3.9
 ----
 
-== Running
+=== Remote Usage
+
+To use the images built from Jenkins, use the full URL:
 
 [source,bash]
 ----
-# Python Version
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.9
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.9 bash
 
 # Git Hash
-docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.9-<hash>
+docker run -it artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.9-<hash> bash
 ----
 
 == Python Version(s)


### PR DESCRIPTION
`README` adjustments.

Also prevents hadolint from getting disabled due to inactivity. GitHub will disable workflows with cron triggers if the repository does not have activity for 60 days. Since the cron trigger is meaningless and this repo does go for periods of time without activity, this effectively prevents hadolint from linting pull-requests that are made after 60 days of inactivity. 
![image](https://user-images.githubusercontent.com/7772179/221491751-d9c4a08e-885d-4256-9cfc-3a9a9fbf06b2.png)
