### PR TITLE
Fix `BUILD_ARGS` and remove Dupe env vars

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -49,7 +49,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "1"))
-        timeout(time: 20, unit: 'MINUTES')
+        timeout(time: 30, unit: 'MINUTES')
         disableConcurrentBuilds()
         timestamps()
     }
@@ -58,10 +58,14 @@ pipeline {
     triggers { cron('H 16 * * 0') }
 
     environment {
+        BUILD_ARGS = "--build-arg 'SLE_VERSION=${SLE_VERSION}' --build-arg 'PY_VERSION=${pythonVersion}' --secret id=SLES_REGISTRATION_CODE"
         DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'A build environment for Python.')
         DOCKER_BUILDKIT = 1
         MULTI_ARCH = 1
         NAME = getRepoName()
+        PY_VERSION = "${pythonVersion}"
+        SLE_VERSION = "${sleVersion}"
+        SLES_REGISTRATION_CODE = credentials('sles15-registration-code')
         TIMESTAMP = sh(returnStdout: true, script: "date '+%Y%m%d%H%M%S'").trim()
         VERSION = "${GIT_COMMIT[0..6]}"
     }
@@ -69,25 +73,13 @@ pipeline {
     stages {
 
         stage('Build') {
-            environment {
-                BUILD_ARGS = "--build-arg 'SLE_VERSION=${sleVersion}' --build-arg 'PY_VERSION=${pythonVersion}'"
-            }
 
             steps {
-                withCredentials([
-                        string(credentialsId: 'sles15-registration-code', variable: 'SLES_REGISTRATION_CODE')
-                ]) {
-                    sh "make image"
-                }
+                sh "make image"
             }
         }
 
         stage('Publish') {
-            environment {
-                SLES_REGISTRATION_CODE = credentials('sles15-registration-code')
-                BUILD_ARGS = "--cache-from type=local,src=docker-build-cache --build-arg 'SLE_VERSION=${sleVersion}' --build-arg 'PY_VERSION=${pythonVersion}' --secret id=SLES_REGISTRATION_CODE"
-            }
-
             steps {
                 script {
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ ifeq ($(DOCKER_BUILDKIT),)
 export DOCKER_BUILDKIT ?= 1
 endif
 
+ifeq ($(BUILD_ARGS),)
+export BUILD_ARGS ?= "--build-arg 'SLE_VERSION=${SLE_VERSION}' --build-arg 'PY_VERSION=${pythonVersion}' --secret id=SLES_REGISTRATION_CODE"
+endif
+
 ifeq ($(SLE_VERSION),)
 export SLE_VERSION := $(shell awk -v replace="'" '/sleVersion/{gsub(replace,"", $$NF); print $$NF; exit}' Jenkinsfile.github)
 endif
@@ -56,8 +60,8 @@ print:
 
 image: print
 	docker buildx build \
-        ${DOCKER_ARGS} \
         ${BUILD_ARGS} \
+        ${DOCKER_ARGS} \
         --cache-to type=local,dest=docker-build-cache  \
         --platform linux/amd64,linux/arm64 \
         --builder $$(docker buildx create --platform linux/amd64,linux/arm64) \
@@ -68,8 +72,8 @@ image: print
 	docker buildx create --use
 
 	docker buildx build \
-        ${DOCKER_ARGS} \
         ${BUILD_ARGS} \
+        ${DOCKER_ARGS} \
         --cache-from type=local,src=docker-build-cache \
         --platform linux/amd64 \
         --secret id=SLES_REGISTRATION_CODE \


### PR DESCRIPTION
Shorten Jenkinsfile, and ensure `BUILD_ARGS` is always defined for CI and non-CI envs.
