### PR TITLE
Set `PYTHON_BIN` for `python-rpm-macros`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,5 @@ RUN python3 -m pip install --disable-pip-version-check --no-cache-dir -U \
     'virtualenv' \
     'wheel'
 
+ENV PYTHON_BIN=python${PY_VERSION}
 WORKDIR /build


### PR DESCRIPTION
Whenever I use these containers, I must remember to set `PYTHON_BIN` for `python-rpm-macros` to work with the container's Python version. If I don't, then `python-rpm-macros` resolves Python to `python3`, and several macros fail (e.g. `%{python_version_nodots}` returns `3`, not `311`).

For example, if I build locally I always have to remember to `export PYTHON_BIN` and pass it to docker, which is tedious.

```bash
export python=python3.11; docker run -e PYTHON_BIN="${python}" --rm --pull always -it -v "$(pwd)":/build "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:${python//python/}" bash
```

I'd prefer to just do:

```bash
docker run --rm --pull always -it -v "$(pwd)":/build "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.11" bash
```
